### PR TITLE
Only iterate over signature and hash algorithms supported by Go TLS

### DIFF
--- a/tls/cfsslscan_common.go
+++ b/tls/cfsslscan_common.go
@@ -95,11 +95,9 @@ var skxsLock sync.Mutex
 
 func init() {
 	defaultSignatureAndHashAlgorithms = supportedSKXSignatureAlgorithms
-	for hash := HashNone; hash <= HashSHA512; hash++ {
-		for signature := SigAnon; signature <= SigECDSA; signature++ {
-			AllSignatureAndHashAlgorithms = append(AllSignatureAndHashAlgorithms,
-				SignatureAndHash{hash, signature})
-		}
+	for _, sighash := range supportedSKXSignatureAlgorithms {
+		AllSignatureAndHashAlgorithms = append(AllSignatureAndHashAlgorithms,
+			SignatureAndHash{hashAlgID(sighash.hash), sigAlgID(sighash.signature)})
 	}
 }
 


### PR DESCRIPTION
When running scans concurrently, there is an issue that signature algorithms unsupported by Go were being sent and the library couldn't handle their verification. This limits the scans to only those signature and has algorithms actually supported.
